### PR TITLE
Implement 220V AC Socket SDF models

### DIFF
--- a/plugin/sdf/CMakeLists.txt
+++ b/plugin/sdf/CMakeLists.txt
@@ -32,6 +32,12 @@ set(MUJOCO_SDF_SRCS
     sdflib.h
     torus.cc
     torus.h
+    socket.cc
+    socket.h
+    sqsocket.cc
+    sqsocket.h
+    sqsocketshell.cc
+    sqsocketshell.h
 )
 
 add_library(sdf SHARED)

--- a/plugin/sdf/register.cc
+++ b/plugin/sdf/register.cc
@@ -17,6 +17,9 @@
 #include "gear.h"
 #include "nut.h"
 #include "torus.h"
+#include "socket.h"
+#include "sqsocket.h"
+#include "sqsocketshell.h"
 #include "sdflib.h"
 
 namespace mujoco::plugin::sdf {
@@ -27,6 +30,9 @@ mjPLUGIN_LIB_INIT {
   Gear::RegisterPlugin();
   Nut::RegisterPlugin();
   Torus::RegisterPlugin();
+  Socket::RegisterPlugin();
+  SqSocket::RegisterPlugin();
+  SqSocketShell::RegisterPlugin();
   SdfLib::RegisterPlugin();
 }
 

--- a/plugin/sdf/socket.cc
+++ b/plugin/sdf/socket.cc
@@ -1,0 +1,197 @@
+// Copyright 2022 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <iostream>
+
+#include <mujoco/mjplugin.h>
+#include <mujoco/mjtnum.h>
+#include <mujoco/mujoco.h>
+#include "sdf.h"
+#include "socket.h"
+
+namespace mujoco::plugin::sdf {
+namespace {
+
+static float opOnion(const mjtNum d1, const mjtNum thickness) {
+    return mju_abs(d1) - thickness;
+}
+
+inline mjtNum opSubtraction(mjtNum a, mjtNum b) {
+    return mju_max(-a, b);
+}
+
+
+// BUG: when h > r, the cylinder is not capped
+static float sdCappedCylinder(const mjtNum p[3], mjtNum h, mjtNum r) {
+    mjtNum pxy[2] = {p[0], p[1]};
+    mjtNum d[2] = {mju_norm(pxy, 2) - r, mju_abs(p[2]) - h};
+    mjtNum d0_capped = mju_max(d[0], 0.0), d1_capped = mju_max(d[1], 0.0);
+    return mju_min(mju_max(d[0], d[1]), 0.0) + mju_sqrt(d0_capped * d0_capped + d1_capped * d1_capped);
+}
+
+
+// port above shadertoy to mujoco
+static mjtNum distance(const mjtNum p[3], const mjtNum attrs[8]) {
+    mjtNum bh = attrs[0];
+    mjtNum br = attrs[1];
+    mjtNum uh = attrs[2];
+    mjtNum uor = attrs[3];
+    mjtNum uir = attrs[4];
+    mjtNum shr = attrs[5];
+    mjtNum shh = attrs[6];
+    mjtNum sho = attrs[7];
+    
+    
+    mjtNum bottomCylinder =  sdCappedCylinder(p, br, br); //sdCappedCylinder(p, bh, br);
+
+    mjtNum p2[3] = {p[0], p[1], p[2]-bh};
+    mjtNum upperOnionCylinder = mju_max(
+        mju_max(
+            opOnion(
+                sdCappedCylinder(p2, uh, uor),
+                uor - uir),
+            -1.0),
+        -1.0);
+    mjtNum p3[3] = {p[0], p[1]  + sho, p[2] - bh};
+    mjtNum socket_left = sdCappedCylinder(p3, shh + bh, shr);
+    
+    mjtNum p4[3] = {p[0] , p[1] - sho, p[2] - bh};
+    mjtNum socket_right = sdCappedCylinder(p4, shh + bh, shr);
+
+
+    mjtNum dist = opSubtraction(
+      Union(socket_left, socket_right),
+      Union(upperOnionCylinder, bottomCylinder)
+    );
+
+    return dist;
+}
+
+
+}  // namespace
+
+// factory function
+std::optional<Socket> Socket::Create(
+    const mjModel* m, mjData* d, int instance) {
+  if (
+    CheckAttr("bottom_height", m, instance) && CheckAttr("bottom_radius", m, instance)
+    && CheckAttr("upper_height", m, instance) && CheckAttr("upper_outer_radius", m, instance) 
+    && CheckAttr("upper_inner_radius", m, instance) && CheckAttr("socket_hole_radius", m, instance) 
+    && CheckAttr("socket_hole_height", m, instance) && CheckAttr("socket_hole_offset", m, instance)) {
+    return Socket(m, d, instance);
+  } else {
+    mju_warning("Invalid radius1 or radius2 parameters in Socket plugin");
+    return std::nullopt;
+  }
+}
+
+// plugin constructor
+Socket::Socket(const mjModel* m, mjData* d, int instance) {
+  SdfDefault<SocketAttribute> defattribute;
+
+  for (int i=0; i < SocketAttribute::nattribute; i++) {
+    attribute[i] = defattribute.GetDefault(
+        SocketAttribute::names[i],
+        mj_getPluginConfig(m, instance, SocketAttribute::names[i]));
+  }
+}
+
+// sdf
+mjtNum Socket::Distance(const mjtNum point[3]) const {
+  return distance(point, attribute);
+}
+
+// gradient of sdf
+void Socket::Gradient(mjtNum grad[3], const mjtNum point[3]) const {
+  mjtNum eps = 1e-8;
+  mjtNum dist0 = distance(point, attribute);
+
+  mjtNum pointX[3] = {point[0]+eps, point[1], point[2]};
+  mjtNum distX = distance(pointX, attribute);
+  mjtNum pointY[3] = {point[0], point[1]+eps, point[2]};
+  mjtNum distY = distance(pointY, attribute);
+  mjtNum pointZ[3] = {point[0], point[1], point[2]+eps};
+  mjtNum distZ = distance(pointZ, attribute);
+
+  grad[0] = (distX - dist0) / eps;
+  grad[1] = (distY - dist0) / eps;
+  grad[2] = (distZ - dist0) / eps;
+}
+
+// plugin registration
+void Socket::RegisterPlugin() {
+  mjpPlugin plugin;
+  mjp_defaultPlugin(&plugin);
+
+  plugin.name = "mujoco.sdf.socket";
+  plugin.capabilityflags |= mjPLUGIN_SDF;
+
+  plugin.nattribute = SocketAttribute::nattribute;
+  plugin.attributes = SocketAttribute::names;
+  plugin.nstate = +[](const mjModel* m, int instance) { return 0; };
+
+  plugin.init = +[](const mjModel* m, mjData* d, int instance) {
+    auto sdf_or_null = Socket::Create(m, d, instance);
+    if (!sdf_or_null.has_value()) {
+      return -1;
+    }
+    d->plugin_data[instance] = reinterpret_cast<uintptr_t>(
+        new Socket(std::move(*sdf_or_null)));
+    return 0;
+  };
+  plugin.destroy = +[](mjData* d, int instance) {
+    delete reinterpret_cast<Socket*>(d->plugin_data[instance]);
+    d->plugin_data[instance] = 0;
+  };
+  plugin.reset = +[](const mjModel* m, double* plugin_state, void* plugin_data,
+                     int instance) {
+    // do nothing
+  };
+  plugin.compute =
+      +[](const mjModel* m, mjData* d, int instance, int capability_bit) {
+        // do nothing;
+      };
+  plugin.sdf_distance =
+      +[](const mjtNum point[3], const mjData* d, int instance) {
+        auto* sdf = reinterpret_cast<Socket*>(d->plugin_data[instance]);
+        return sdf->Distance(point);
+      };
+  plugin.sdf_gradient = +[](mjtNum gradient[3], const mjtNum point[3],
+                        const mjData* d, int instance) {
+    auto* sdf = reinterpret_cast<Socket*>(d->plugin_data[instance]);
+    sdf->Gradient(gradient, point);
+  };
+  plugin.sdf_staticdistance =
+      +[](const mjtNum point[3], const mjtNum* attributes) {
+        return distance(point, attributes);
+      };
+  plugin.sdf_aabb =
+      +[](mjtNum aabb[6], const mjtNum* attributes) {
+        aabb[0] = aabb[1] = aabb[2] = 0;
+        aabb[3] = aabb[4] = attributes[0] + attributes[1];
+        aabb[5] = attributes[1];
+      };
+  plugin.sdf_attribute =
+      +[](mjtNum attribute[], const char* name[], const char* value[]) {
+        SdfDefault<SocketAttribute> defattribute;
+        defattribute.GetDefaults(attribute, name, value);
+      };
+
+  mjp_registerPlugin(&plugin);
+}
+
+}  // namespace mujoco::plugin::sdf

--- a/plugin/sdf/socket.h
+++ b/plugin/sdf/socket.h
@@ -1,0 +1,57 @@
+// Copyright 2022 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUJOCO_PLUGIN_SDF_SOCKET_H_
+#define MUJOCO_PLUGIN_SDF_SOCKET_H_
+
+#include <optional>
+
+#include <mujoco/mjdata.h>
+#include <mujoco/mjmodel.h>
+#include <mujoco/mjtnum.h>
+#include "sdf.h"
+
+namespace mujoco::plugin::sdf {
+
+struct SocketAttribute {
+  static constexpr int nattribute = 8;
+  static constexpr char const* names[nattribute] = {
+    "bottom_height", "bottom_radius", 
+    "upper_height", "upper_outer_radius", "upper_inner_radius",
+    "socket_hole_radius", "socket_hole_height", "socket_hole_offset",
+    };
+  static constexpr mjtNum defaults[nattribute] = { .024, .0175, .011, .0217, 0.0195, 0.0027, 0.008, 0.009};
+};
+
+class Socket {
+ public:
+  // Creates a new Socket instance or returns null on failure.
+  static std::optional<Socket> Create(const mjModel* m, mjData* d, int instance);
+  Socket(Socket&&) = default;
+  ~Socket() = default;
+
+  mjtNum Distance(const mjtNum point[3]) const;
+  void Gradient(mjtNum grad[3], const mjtNum point[3]) const;
+
+  static void RegisterPlugin();
+
+  mjtNum attribute[SocketAttribute::nattribute];
+
+ private:
+  Socket(const mjModel* m, mjData* d, int instance);
+};
+
+}  // namespace mujoco::plugin::sdf
+
+#endif  // MUJOCO_PLUGIN_SDF_SOCKET_H_

--- a/plugin/sdf/sqsocket.cc
+++ b/plugin/sdf/sqsocket.cc
@@ -68,7 +68,7 @@ static mjtNum distance(const mjtNum p[3], const mjtNum attrs[11]) {
   mjtNum boxOffset[3] = {bx, by, bz};
   mjtNum bodyBox =  sdRoundBox(p, boxOffset, br);
 
-  mjtNum cupPos[3] = {p[0] - cy, p[1] - by, p[2] - cy};
+  mjtNum cupPos[3] = {p[0] - cx, p[1] - by, p[2] - cy};
   mjtNum cup = sdCappedCylinder(cupPos, ch, cr);
   
   mjtNum leftHolePos[3] = {cupPos[0], cupPos[1] + ch, cupPos[2] + sho};

--- a/plugin/sdf/sqsocket.cc
+++ b/plugin/sdf/sqsocket.cc
@@ -27,11 +27,6 @@ namespace mujoco::plugin::sdf {
 namespace {
 
 
-static float opOnion(const mjtNum d1, const mjtNum thickness) {
-  return mju_abs(d1) - thickness;
-}
-
-
 inline mjtNum opSubtraction(mjtNum a, mjtNum b) {
   return mju_max(-a, b);
 }

--- a/plugin/sdf/sqsocket.cc
+++ b/plugin/sdf/sqsocket.cc
@@ -1,0 +1,202 @@
+// Copyright 2022 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <iostream>
+
+#include <mujoco/mjplugin.h>
+#include <mujoco/mjtnum.h>
+#include <mujoco/mujoco.h>
+#include "sdf.h"
+#include "sqsocket.h"
+
+namespace mujoco::plugin::sdf {
+namespace {
+
+
+static float opOnion(const mjtNum d1, const mjtNum thickness) {
+    return mju_abs(d1) - thickness;
+}
+
+
+inline mjtNum opSubtraction(mjtNum a, mjtNum b) {
+    return mju_max(-a, b);
+}
+
+
+static mjtNum sdCappedCylinder(const mjtNum p[3], mjtNum h, mjtNum r) {
+    mjtNum pxy[2] = {p[0], p[2]};
+    mjtNum d[2] = {mju_norm(pxy, 2) - r, mju_abs(p[1]) - h};
+    mjtNum d0_capped = mju_max(d[0], 0.0), d1_capped = mju_max(d[1], 0.0);
+    return mju_min(mju_max(d[0], d[1]), 0.0) + mju_sqrt(d0_capped * d0_capped + d1_capped * d1_capped);
+}
+
+
+static mjtNum sdRoundBox(const mjtNum p[3], const mjtNum b[3], mjtNum r) {
+    const mjtNum q[3] = {mju_abs(p[0]) - b[0], mju_abs(p[1]) - b[1], mju_abs(p[2]) - b[2]};
+    const mjtNum cappedQ[3] = {mju_max(q[0], 0.0), mju_max(q[1], 0.0), mju_max(q[2], 0.0)} ;
+    return mju_norm3(cappedQ) + mju_min(mju_max(q[0], mju_max(q[1], q[2])), 0.0);
+}
+
+
+static mjtNum distance(const mjtNum p[3], const mjtNum attrs[11]) {
+    mjtNum box_x = attrs[0];
+    mjtNum box_y = attrs[1];
+    mjtNum box_z = attrs[2];
+    mjtNum box_rounding = attrs[3];
+    mjtNum hole_xpos = attrs[4];
+    mjtNum hole_ypos = attrs[5];
+    mjtNum hole_height = attrs[6];
+    mjtNum hole_radius = attrs[7];
+    mjtNum sqsocket_conn_radius = attrs[8];
+    mjtNum sqsocket_conn_height = attrs[9];
+    mjtNum sqsocket_conn_offset = attrs[10];
+    
+    mjtNum box_offset[3] = {box_x, box_y, box_z};
+    mjtNum body_box =  sdRoundBox(p, box_offset, box_rounding); //sdCappedCylinder(p, bh, br);
+
+    mjtNum hole_pos[3] = {p[0] - hole_xpos, p[1] - box_y, p[2] - hole_ypos};
+    mjtNum hole = sdCappedCylinder(hole_pos, hole_height, hole_radius);
+    
+    mjtNum left_conn_pos[3] = {hole_pos[0], hole_pos[1] + hole_height, hole_pos[2] + sqsocket_conn_offset};
+    mjtNum sqsocket_left = sdCappedCylinder(left_conn_pos, sqsocket_conn_height, sqsocket_conn_radius);
+    
+    mjtNum right_conn_pos[3] = {hole_pos[0] , hole_pos[1] + hole_height, hole_pos[2] - sqsocket_conn_offset};
+    mjtNum sqsocket_right = sdCappedCylinder(right_conn_pos, sqsocket_conn_height, sqsocket_conn_radius);
+
+    mjtNum dist = Subtraction(body_box, Union(hole, Union(sqsocket_left, sqsocket_right)));
+    
+    return dist;
+}
+
+
+}  // namespace
+
+
+// factory function
+std::optional<SqSocket> SqSocket::Create(
+    const mjModel* m, mjData* d, int instance) {
+  if (
+    CheckAttr("box_x", m, instance) && CheckAttr("box_y", m, instance) 
+    && CheckAttr("box_z", m, instance) && CheckAttr("box_rounding", m, instance) 
+    && CheckAttr("hole_xpos", m, instance) && CheckAttr("hole_ypos", m, instance) 
+    && CheckAttr("hole_height", m, instance) && CheckAttr("hole_radius", m, instance)
+    && CheckAttr("sqsocket_conn_radius", m, instance) && CheckAttr("sqsocket_conn_height", m, instance)
+    && CheckAttr("sqsocket_conn_offset", m, instance)
+  ) {
+    return SqSocket(m, d, instance);
+  } else {
+    mju_warning("Invalid radius1 or radius2 parameters in SqSocket plugin");
+    return std::nullopt;
+  }
+}
+
+// plugin constructor
+SqSocket::SqSocket(const mjModel* m, mjData* d, int instance) {
+  SdfDefault<SqSocketAttribute> defattribute;
+
+  for (int i=0; i < SqSocketAttribute::nattribute; i++) {
+    attribute[i] = defattribute.GetDefault(
+        SqSocketAttribute::names[i],
+        mj_getPluginConfig(m, instance, SqSocketAttribute::names[i]));
+  }
+}
+
+// sdf
+mjtNum SqSocket::Distance(const mjtNum point[3]) const {
+  return distance(point, attribute);
+}
+
+// gradient of sdf
+void SqSocket::Gradient(mjtNum grad[3], const mjtNum point[3]) const {
+  mjtNum eps = 1e-8;
+  mjtNum dist0 = distance(point, attribute);
+
+  mjtNum pointX[3] = {point[0]+eps, point[1], point[2]};
+  mjtNum distX = distance(pointX, attribute);
+  mjtNum pointY[3] = {point[0], point[1]+eps, point[2]};
+  mjtNum distY = distance(pointY, attribute);
+  mjtNum pointZ[3] = {point[0], point[1], point[2]+eps};
+  mjtNum distZ = distance(pointZ, attribute);
+
+  grad[0] = (distX - dist0) / eps;
+  grad[1] = (distY - dist0) / eps;
+  grad[2] = (distZ - dist0) / eps;
+}
+
+// plugin registration
+void SqSocket::RegisterPlugin() {
+  mjpPlugin plugin;
+  mjp_defaultPlugin(&plugin);
+
+  plugin.name = "mujoco.sdf.sqsocket";
+  plugin.capabilityflags |= mjPLUGIN_SDF;
+
+  plugin.nattribute = SqSocketAttribute::nattribute;
+  plugin.attributes = SqSocketAttribute::names;
+  plugin.nstate = +[](const mjModel* m, int instance) { return 0; };
+
+  plugin.init = +[](const mjModel* m, mjData* d, int instance) {
+    auto sdf_or_null = SqSocket::Create(m, d, instance);
+    if (!sdf_or_null.has_value()) {
+      return -1;
+    }
+    d->plugin_data[instance] = reinterpret_cast<uintptr_t>(
+        new SqSocket(std::move(*sdf_or_null)));
+    return 0;
+  };
+  plugin.destroy = +[](mjData* d, int instance) {
+    delete reinterpret_cast<SqSocket*>(d->plugin_data[instance]);
+    d->plugin_data[instance] = 0;
+  };
+  plugin.reset = +[](const mjModel* m, double* plugin_state, void* plugin_data,
+                     int instance) {
+    // do nothing
+  };
+  plugin.compute =
+      +[](const mjModel* m, mjData* d, int instance, int capability_bit) {
+        // do nothing;
+      };
+  plugin.sdf_distance =
+      +[](const mjtNum point[3], const mjData* d, int instance) {
+        auto* sdf = reinterpret_cast<SqSocket*>(d->plugin_data[instance]);
+        return sdf->Distance(point);
+      };
+  plugin.sdf_gradient = +[](mjtNum gradient[3], const mjtNum point[3],
+                        const mjData* d, int instance) {
+    auto* sdf = reinterpret_cast<SqSocket*>(d->plugin_data[instance]);
+    sdf->Gradient(gradient, point);
+  };
+  plugin.sdf_staticdistance =
+      +[](const mjtNum point[3], const mjtNum* attributes) {
+        return distance(point, attributes);
+      };
+  plugin.sdf_aabb =
+      +[](mjtNum aabb[6], const mjtNum* attributes) {
+        aabb[0] = aabb[1] = aabb[2] = 0;
+        aabb[3] = aabb[4] = attributes[0] + attributes[1];
+        aabb[5] = attributes[1];
+      };
+  plugin.sdf_attribute =
+      +[](mjtNum attribute[], const char* name[], const char* value[]) {
+        SdfDefault<SqSocketAttribute> defattribute;
+        defattribute.GetDefaults(attribute, name, value);
+      };
+
+  mjp_registerPlugin(&plugin);
+}
+
+}  // namespace mujoco::plugin::sdf

--- a/plugin/sdf/sqsocket.h
+++ b/plugin/sdf/sqsocket.h
@@ -1,0 +1,57 @@
+// Copyright 2022 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUJOCO_PLUGIN_SDF_SQSOCKET_H_
+#define MUJOCO_PLUGIN_SDF_SQSOCKET_H_
+
+#include <optional>
+
+#include <mujoco/mjdata.h>
+#include <mujoco/mjmodel.h>
+#include <mujoco/mjtnum.h>
+#include "sdf.h"
+
+namespace mujoco::plugin::sdf {
+
+struct SqSocketAttribute {
+  static constexpr int nattribute = 11;
+  static constexpr char const* names[nattribute] = {
+    "box_x", "box_y", "box_z", "box_rounding", 
+    "hole_xpos", "hole_ypos", "hole_height", "hole_radius",
+    "sqsocket_conn_radius", "sqsocket_conn_height", "sqsocket_conn_offset",
+    };
+  static constexpr mjtNum defaults[nattribute] = { .0245, .033, .0245, .003, 0.0, 0.0, 0.009, 0.0195, 0.0024, 0.02, 0.009};
+};
+
+class SqSocket {
+ public:
+  // Creates a new SqSocket instance or returns null on failure.
+  static std::optional<SqSocket> Create(const mjModel* m, mjData* d, int instance);
+  SqSocket(SqSocket&&) = default;
+  ~SqSocket() = default;
+
+  mjtNum Distance(const mjtNum point[3]) const;
+  void Gradient(mjtNum grad[3], const mjtNum point[3]) const;
+
+  static void RegisterPlugin();
+
+  mjtNum attribute[SqSocketAttribute::nattribute];
+
+ private:
+  SqSocket(const mjModel* m, mjData* d, int instance);
+};
+
+}  // namespace mujoco::plugin::sdf
+
+#endif  // MUJOCO_PLUGIN_SDF_SQSOCKET_H_

--- a/plugin/sdf/sqsocketshell.cc
+++ b/plugin/sdf/sqsocketshell.cc
@@ -28,36 +28,37 @@ namespace {
 
 
 inline mjtNum opSubtraction(mjtNum a, mjtNum b) {
-    return mju_max(-a, b);
+  return mju_max(-a, b);
 }
 
 
 static mjtNum sdRoundBox(const mjtNum p[3], const mjtNum b[3], mjtNum r) {
-    const mjtNum q[3] = {mju_abs(p[0]) - b[0], mju_abs(p[1]) - b[1], mju_abs(p[2]) - b[2]};
-    const mjtNum cappedQ[3] = {mju_max(q[0], 0.0), mju_max(q[1], r), mju_max(q[2], 0.0)} ;
-    return mju_norm3(cappedQ) + mju_min(mju_max(q[0], mju_max(q[1], q[2])), 0.0) - r;
+  const mjtNum q[3] = {mju_abs(p[0]) - b[0], mju_abs(p[1]) - b[1], mju_abs(p[2]) - b[2]};
+  const mjtNum cappedQ[3] = {mju_max(q[0], 0.0), mju_max(q[1], r), mju_max(q[2], 0.0)} ;
+  return mju_norm3(cappedQ) + mju_min(mju_max(q[0], mju_max(q[1], q[2])), 0.0) - r;
 }
 
 
 static mjtNum distance(const mjtNum p[3], const mjtNum attrs[8]) {
-    mjtNum outbox_x = attrs[0];
-    mjtNum outbox_y = attrs[1];
-    mjtNum outbox_z = attrs[2];
-    mjtNum outbox_rounding = attrs[3];
-    mjtNum inbox_x = attrs[4];
-    mjtNum inbox_y = attrs[5];
-    mjtNum inbox_z = attrs[6];
-    mjtNum inbox_rounding = attrs[7];
-    
-    mjtNum outbox_offset[3] = {outbox_x, outbox_y, outbox_z};
-    mjtNum outbox = sdRoundBox(p, outbox_offset, outbox_rounding); //sdCappedCylinder(p, bh, br);
+  // All box lengths are half, as they extend in both directions from the origin
+  mjtNum ox = attrs[0];  // Outer box x width
+  mjtNum oy = attrs[1];  // Outer box y height 
+  mjtNum oz = attrs[2];  // Outer box z depth
+  mjtNum or_ = attrs[3];  // Outer box rounding
+  mjtNum ix = attrs[4];  // Inner box x width
+  mjtNum iy = attrs[5];  // Inner box y height
+  mjtNum iz = attrs[6];  // Inner box z depth
+  mjtNum ir = attrs[7];  // Inner box rounding
+  
+  mjtNum outboxOffset[3] = {ox, oy, oz};
+  mjtNum outbox = sdRoundBox(p, outboxOffset, or_); //sdCappedCylinder(p, bh, br);
 
-    mjtNum inbox_offset[3] = {inbox_x, inbox_y, inbox_z};
-    mjtNum inbox = sdRoundBox(p, inbox_offset, inbox_rounding); //sdCappedCylinder(p, bh, br);
+  mjtNum inboxOffset[3] = {ix, iy, iz};
+  mjtNum inbox = sdRoundBox(p, inboxOffset, ir); //sdCappedCylinder(p, bh, br);
 
-    mjtNum dist = Subtraction(outbox, inbox);
-    
-    return dist;
+  mjtNum dist = Subtraction(outbox, inbox);
+  
+  return dist;
 }
 
 

--- a/plugin/sdf/sqsocketshell.cc
+++ b/plugin/sdf/sqsocketshell.cc
@@ -1,0 +1,178 @@
+// Copyright 2022 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <iostream>
+
+#include <mujoco/mjplugin.h>
+#include <mujoco/mjtnum.h>
+#include <mujoco/mujoco.h>
+#include "sdf.h"
+#include "sqsocketshell.h"
+
+namespace mujoco::plugin::sdf {
+namespace {
+
+
+inline mjtNum opSubtraction(mjtNum a, mjtNum b) {
+    return mju_max(-a, b);
+}
+
+
+static mjtNum sdRoundBox(const mjtNum p[3], const mjtNum b[3], mjtNum r) {
+    const mjtNum q[3] = {mju_abs(p[0]) - b[0], mju_abs(p[1]) - b[1], mju_abs(p[2]) - b[2]};
+    const mjtNum cappedQ[3] = {mju_max(q[0], 0.0), mju_max(q[1], r), mju_max(q[2], 0.0)} ;
+    return mju_norm3(cappedQ) + mju_min(mju_max(q[0], mju_max(q[1], q[2])), 0.0) - r;
+}
+
+
+static mjtNum distance(const mjtNum p[3], const mjtNum attrs[8]) {
+    mjtNum outbox_x = attrs[0];
+    mjtNum outbox_y = attrs[1];
+    mjtNum outbox_z = attrs[2];
+    mjtNum outbox_rounding = attrs[3];
+    mjtNum inbox_x = attrs[4];
+    mjtNum inbox_y = attrs[5];
+    mjtNum inbox_z = attrs[6];
+    mjtNum inbox_rounding = attrs[7];
+    
+    mjtNum outbox_offset[3] = {outbox_x, outbox_y, outbox_z};
+    mjtNum outbox = sdRoundBox(p, outbox_offset, outbox_rounding); //sdCappedCylinder(p, bh, br);
+
+    mjtNum inbox_offset[3] = {inbox_x, inbox_y, inbox_z};
+    mjtNum inbox = sdRoundBox(p, inbox_offset, inbox_rounding); //sdCappedCylinder(p, bh, br);
+
+    mjtNum dist = Subtraction(outbox, inbox);
+    
+    return dist;
+}
+
+
+}  // namespace
+
+
+// factory function
+std::optional<SqSocketShell> SqSocketShell::Create(
+    const mjModel* m, mjData* d, int instance) {
+  if (
+    CheckAttr("outbox_x", m, instance) && CheckAttr("outbox_y", m, instance) 
+    && CheckAttr("outbox_z", m, instance) && CheckAttr("outbox_rounding", m, instance)
+    && CheckAttr("inbox_x", m, instance) && CheckAttr("inbox_y", m, instance)
+    && CheckAttr("inbox_z", m, instance) && CheckAttr("inbox_rounding", m, instance)
+  ) {
+    return SqSocketShell(m, d, instance);
+  } else {
+    mju_warning("Invalid radius1 or radius2 parameters in SqSocketShell plugin");
+    return std::nullopt;
+  }
+}
+
+// plugin constructor
+SqSocketShell::SqSocketShell(const mjModel* m, mjData* d, int instance) {
+  SdfDefault<SqSocketShellAttribute> defattribute;
+
+  for (int i=0; i < SqSocketShellAttribute::nattribute; i++) {
+    attribute[i] = defattribute.GetDefault(
+        SqSocketShellAttribute::names[i],
+        mj_getPluginConfig(m, instance, SqSocketShellAttribute::names[i]));
+  }
+}
+
+// sdf
+mjtNum SqSocketShell::Distance(const mjtNum point[3]) const {
+  return distance(point, attribute);
+}
+
+// gradient of sdf
+void SqSocketShell::Gradient(mjtNum grad[3], const mjtNum point[3]) const {
+  mjtNum eps = 1e-8;
+  mjtNum dist0 = distance(point, attribute);
+
+  mjtNum pointX[3] = {point[0]+eps, point[1], point[2]};
+  mjtNum distX = distance(pointX, attribute);
+  mjtNum pointY[3] = {point[0], point[1]+eps, point[2]};
+  mjtNum distY = distance(pointY, attribute);
+  mjtNum pointZ[3] = {point[0], point[1], point[2]+eps};
+  mjtNum distZ = distance(pointZ, attribute);
+
+  grad[0] = (distX - dist0) / eps;
+  grad[1] = (distY - dist0) / eps;
+  grad[2] = (distZ - dist0) / eps;
+}
+
+// plugin registration
+void SqSocketShell::RegisterPlugin() {
+  mjpPlugin plugin;
+  mjp_defaultPlugin(&plugin);
+
+  plugin.name = "mujoco.sdf.sqsocketshell";
+  plugin.capabilityflags |= mjPLUGIN_SDF;
+
+  plugin.nattribute = SqSocketShellAttribute::nattribute;
+  plugin.attributes = SqSocketShellAttribute::names;
+  plugin.nstate = +[](const mjModel* m, int instance) { return 0; };
+
+  plugin.init = +[](const mjModel* m, mjData* d, int instance) {
+    auto sdf_or_null = SqSocketShell::Create(m, d, instance);
+    if (!sdf_or_null.has_value()) {
+      return -1;
+    }
+    d->plugin_data[instance] = reinterpret_cast<uintptr_t>(
+        new SqSocketShell(std::move(*sdf_or_null)));
+    return 0;
+  };
+  plugin.destroy = +[](mjData* d, int instance) {
+    delete reinterpret_cast<SqSocketShell*>(d->plugin_data[instance]);
+    d->plugin_data[instance] = 0;
+  };
+  plugin.reset = +[](const mjModel* m, double* plugin_state, void* plugin_data,
+                     int instance) {
+    // do nothing
+  };
+  plugin.compute =
+      +[](const mjModel* m, mjData* d, int instance, int capability_bit) {
+        // do nothing;
+      };
+  plugin.sdf_distance =
+      +[](const mjtNum point[3], const mjData* d, int instance) {
+        auto* sdf = reinterpret_cast<SqSocketShell*>(d->plugin_data[instance]);
+        return sdf->Distance(point);
+      };
+  plugin.sdf_gradient = +[](mjtNum gradient[3], const mjtNum point[3],
+                        const mjData* d, int instance) {
+    auto* sdf = reinterpret_cast<SqSocketShell*>(d->plugin_data[instance]);
+    sdf->Gradient(gradient, point);
+  };
+  plugin.sdf_staticdistance =
+      +[](const mjtNum point[3], const mjtNum* attributes) {
+        return distance(point, attributes);
+      };
+  plugin.sdf_aabb =
+      +[](mjtNum aabb[6], const mjtNum* attributes) {
+        aabb[0] = aabb[1] = aabb[2] = 0;
+        aabb[3] = aabb[4] = attributes[0] + attributes[1];
+        aabb[5] = attributes[1];
+      };
+  plugin.sdf_attribute =
+      +[](mjtNum attribute[], const char* name[], const char* value[]) {
+        SdfDefault<SqSocketShellAttribute> defattribute;
+        defattribute.GetDefaults(attribute, name, value);
+      };
+
+  mjp_registerPlugin(&plugin);
+}
+
+}  // namespace mujoco::plugin::sdf

--- a/plugin/sdf/sqsocketshell.h
+++ b/plugin/sdf/sqsocketshell.h
@@ -1,0 +1,56 @@
+// Copyright 2022 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUJOCO_PLUGIN_SDF_SQSOCKETSHELL_H_
+#define MUJOCO_PLUGIN_SDF_SQSOCKETSHELL_H_
+
+#include <optional>
+
+#include <mujoco/mjdata.h>
+#include <mujoco/mjmodel.h>
+#include <mujoco/mjtnum.h>
+#include "sdf.h"
+
+namespace mujoco::plugin::sdf {
+
+struct SqSocketShellAttribute {
+  static constexpr int nattribute = 8;
+  static constexpr char const* names[nattribute] = {
+    "outbox_x", "outbox_y", "outbox_z", "outbox_rounding", 
+    "inbox_x", "inbox_y", "inbox_z", "inbox_rounding", 
+    };
+  static constexpr mjtNum defaults[nattribute] = { 0.028, 0.033, 0.028, 0.004, 0.0245, 0.033, 0.0245, 0.002};
+};
+
+class SqSocketShell {
+ public:
+  // Creates a new SqSocketShell instance or returns null on failure.
+  static std::optional<SqSocketShell> Create(const mjModel* m, mjData* d, int instance);
+  SqSocketShell(SqSocketShell&&) = default;
+  ~SqSocketShell() = default;
+
+  mjtNum Distance(const mjtNum point[3]) const;
+  void Gradient(mjtNum grad[3], const mjtNum point[3]) const;
+
+  static void RegisterPlugin();
+
+  mjtNum attribute[SqSocketShellAttribute::nattribute];
+
+ private:
+  SqSocketShell(const mjModel* m, mjData* d, int instance);
+};
+
+}  // namespace mujoco::plugin::sdf
+
+#endif  // MUJOCO_PLUGIN_SDF_SQSOCKETSHELL_H_


### PR DESCRIPTION
## 설명

<!--
  여러개의 Issue를 하나의 PR에 묶고 싶은 경우:
  "Issue Number: close " 옆에 Issue 번호를 함께 추가하세요. 자동으로 issue를 연결해줍니다.
  ex) Issue Number: close #23
-->
Issue Number: close #1 

220V AC 소켓의 충돌 모델을 [SDF 플러그인](https://github.com/PLAIF-dev/mujoco/blob/main/plugin/sdf/README.md)을 이용해 구현했습니다. Mujoco는 Convex hull 충돌만 지원하기 때문에 소켓 같이 움푹 파인 모델은 구현하기 힘들었습니다. ([박스를 여러 개 겹쳐서](https://github.com/google-deepmind/mujoco/discussions/19) 만들거나 합니다.)

SDF를 이용하면 임의의 모양의 물체에 대해 더 정확하고 빠른 충돌 모델 구현이 가능합니다.

빌드 및 Python binding .whl 생성 방법은 Notion에 정리해뒀습니다. https://www.notion.so/plaif/Mujoco-build-from-source-Python-binding-48ebc718ecfa4cc59e650824f8fb6953?pvs=4

## 체크리스트

제출한 Pull Request가 다음 사항을 만족하는지 확인해주세요:

- [x] 👮 변경 내용이 규칙(lint rules, business rules 등)을 준수합니다.
- [x] 📝 bug fix나 feature 추가의 경우 변경 내용을 문서화하였습니다.
- [x] 😊 커밋 메시지가 변경 내용을 충분히 설명하고 있습니다.
- [x] 💯 코드를 추가/변경한 경우 기존 테스트를 잘 통과하고, 필요한 경우 적절한 테스트를 작성 하였습니다.
